### PR TITLE
orn.mod can setup with either noiseFromRandom or noiseFromRandom123.

### DIFF
--- a/sim/orn.mod
+++ b/sim/orn.mod
@@ -144,10 +144,6 @@ BREAKPOINT {
 	SOLVE oup
         SOLVE states METHOD derivimplicit
         
-:	if(tau_e==0) {
-:	   g_e = std_e * normrand123()
-:	}
-
         SORN = O * (1-D)
         
         g_e = g_e1 + SORN * cc_peak * g_e_max + g_e_baseline


### PR DESCRIPTION
The latter allows quantitatve validation with CoreNEURON as it uses
the same implementation for the normal distribution. Currently, the former is being used in
```
mitral.hoc:                synodor.noiseFromRandom(synrng)
mtufted.hoc:                synodor.noiseFromRandom(synrng)
```

Note that this mod file requires a NEURON version that implements nrn_random_reset
That is pull request 620 in neuronsimulator/nrn
Alternatively one can modify NEURON with
```
diff --git a/src/gnu/Normal.cpp b/src/gnu/Normal.cpp
index 436827f0..a191ad56 100755
--- a/src/gnu/Normal.cpp
+++ b/src/gnu/Normal.cpp
@@ -51,7 +51,7 @@ double Normal::operator()()
                double x1 = v1 * y;
                double x2 = v2 * y;
                
-               haveCachedNormal = 1;
+//             haveCachedNormal = 1;
                cachedNormal = x2;
                return(x1 * pStdDev + pMean);
            }
```