### PR TITLE
Spike format consistent with binary exact dt = 1/64 + 1/128

### DIFF
--- a/sim/parrun.py
+++ b/sim/parrun.py
@@ -30,7 +30,9 @@ def prun(tstop):
 
   inittime = h.startsw()
   cvode.active(0)
-#  if rank == 0: print 'cvode active=', cvode.active()
+  if rank == 0: print 'cvode active=', cvode.active()
+  h.stdinit()
+  pc.nrncore_run("-e %g --voltage 1000." % (tstop, ), 0)
   h.stdinit()
   inittime = h.startsw() - inittime
   if rank == 0:
@@ -55,8 +57,6 @@ def prun(tstop):
         #tnext_clean += clean_weights_interval
    
     pc.psolve(tnext)
-    
-    
 
 #    if rank == 0:
 #      print 'sim. checkpoint at %g' % h.t
@@ -71,7 +71,7 @@ def prun(tstop):
     import binsave
     binsave.save(params.filename, spikevec, idvec)
     
-#    h.spike2file(params.filename, spikevec, idvec, n_spkout_sort, n_spkout_files)
+    h.spike2file(params.filename, spikevec, idvec, n_spkout_sort, n_spkout_files)
   
   runtime = h.startsw() - runtime
   comptime = pc.step_time()

--- a/sim/spike2file.hoc
+++ b/sim/spike2file.hoc
@@ -12,7 +12,7 @@ proc sortspikes() {local res, i, j, k, imin, x, nbin, tmin, tmax, tvl, spikecoun
 	nbin = $5 // number of ranks (from 0) to do the sorting
 	if (nbin > pc.nhost) { nbin = pc.nhost }
 	// for testing, round to the file output resolution
-	if (1) {
+	if (0) {
 		res = .00001
 		s1.div(res).add(.5).floor().mul(res)
 	}
@@ -128,7 +128,7 @@ proc spike2file() { local i, j, nf, me, ts, nbin, nspike, nbinperfile \
 			outf.aopen(s.s)
 			for i=0, vs.size-1  {
 				//outf.printf("%.5f %d\n", vs.x[i], vg.x[i])
-				outf.printf("%.10g %d\n", vs.x[i], vg.x[i])
+				outf.printf("%.7f %d\n", vs.x[i], vg.x[i])
 			}
 			outf.close
 		}


### PR DESCRIPTION
(Though the actual dt is twice that).
Appropriate nrncore_run parameters.

For easy comparison with out.dat from coreneuron, it is helpful to
```
+++ b/coreneuron/io/output_spikes.cpp
@@ -191,7 +191,7 @@ void output_spikes_parallel(const char* outpath) {
     char spike_entry[SPIKE_RECORD_LEN];
     unsigned spike_data_offset = 0;
     for (unsigned i = 0; i < num_spikes; i++) {
-        int spike_entry_chars = snprintf(spike_entry, 64, "%.8g\t%d\n", spikevec_time[i], spikevec_gid[i]);
+        int spike_entry_chars = snprintf(spike_entry, 64, "%.7f %d\n", spikevec_time[i], spikevec_gid[i]);
         spike_data_offset = strcat_at_pos(spike_data, spike_data_offset, spike_entry, spike_entry_chars);
     }
```