### PR TITLE
Python 2 to Python 3 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module load spectrum_mpi/10.3.1--binary boost/1.72.0--spectrum_mpi--10.3.1--bina
 export PYTHONPATH=/m100_work/Pra18_4575_0/software/gpu/install/lib64/python/:$PYTHONPATH
 
 # gpu run with coreneuron
-mpirun ./special_wrapper.ppc64 -python -mpi bulb3dtest.py
+mpirun ./special_wrapper.ppc64 -python -mpi bulb3dtest.py 1050 1 1 0 output
 ```
 
 Note that we are using `special_wrapper.ppc64` instead of `ppc64le/special` as a binary to launch. This is because [MPS](https://docs.nvidia.com/deploy/pdf/CUDA_Multi_Process_Service_Overview.pdf) service is currently not enabled on Marconi100. Using wrapper script, we start the MPS service before launching an application.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,48 @@
 ## How to run this model on Marconi100
 
-#### Installing NEURON+CoreNEURON
+### Installing NEURON+CoreNEURON from Source
 
-NEURON+CoreNEURON has been already installed at below location on Marconi100:
+First we need to build NEURON with CoreNEURON support. In order to do so, you can use following script:
 
+```console
+module load profile/base
+module load profile/advanced
+module load hpc-sdk/2021--binary gnu/8.4.0 cuda/11.0
+module load spectrum_mpi/10.3.1--binary boost/1.72.0--spectrum_mpi--10.3.1--binary
+module load cmake/3.20.0 python/3.8.2
+
+export OMPI_CXX=nvc++
+export OMPI_CC=nvc
+export CC=mpicc
+export CXX=mpicxx
+
+git clone https://github.com/neuronsimulator/nrn.git
+
+mkdir -p nrn/build && cd nrn/build
+
+# cmake, make and make install
+cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/install \
+	-DNRN_ENABLE_INTERVIEWS=OFF \
+	-DNRN_ENABLE_RX3D=OFF \
+	-DNRN_ENABLE_CORENEURON=ON \
+	-DPYTHON_EXECUTABLE=`which python` \
+	-DCORENRN_ENABLE_MPI=ON \
+	-DCORENRN_ENABLE_OPENMP=OFF \
+	-DCORENRN_ENABLE_GPU=ON
+make -j8
+make install
 ```
-/m100_work/Pra18_4575_0/software/gpu/install
-```
 
-We can use this installation for execution on Marconi100. If you want to re-build it from source, see the instructions at the end of this README file.
+Note that above mentioned modules (from May 2022) might change in the future. So make sure to change them if necessary.
 
 #### Download Model
 
-Let's clone olfactory bulb model repository from GitHub:
+Let's clone olfactory bulb model repository from GitHub. For now, we have to use `2to3` branch which has Python 3 support:
 
 ```
 git clone https://github.com/HumanBrainProject/olfactory-bulb-3d.git
 cd olfactory-bulb-3d/sim
+git checkout 2to3
 ```
 
 #### Building Special
@@ -24,18 +50,18 @@ cd olfactory-bulb-3d/sim
 We can now build the model `nrnivmodl -coreneuron ` command. Make sure to change path of `nrnivmodl` if you have installed NEURON from source.
 
 ```
+module load profile/base
 module load profile/advanced
-module load pgi/19.10--binary gnu/8.4.0 cuda/10.1
+module load hpc-sdk/2021--binary gnu/8.4.0 cuda/11.0
 module load spectrum_mpi/10.3.1--binary boost/1.72.0--spectrum_mpi--10.3.1--binary
-module load cmake/3.17.1
+module load cmake/3.20.0 python/3.8.2
 
-export PGI_LOCALRC=/m100_work/Pra18_4575_0/software/gpu/pgi/localrc
-export OMPI_CXX=pgc++
-export OMPI_CC=pgcc
+export OMPI_CXX=nvc++
+export OMPI_CC=nvc
 export CC=mpicc
 export CXX=mpicxx
 
-/m100_work/Pra18_4575_0/software/gpu/install/bin/nrnivmodl -coreneuron .
+$HOME/install/bin/nrnivmodl -coreneuron .
 ```
 
 If there are no errors, `special` with CoreNEURON support will be built.
@@ -62,11 +88,13 @@ We can now submit the job to the cluster using following job script:
 #SBATCH --ntasks-per-node=8
 #SBATCH --gres=gpu:4
 
+module load profile/base
 module load profile/advanced
-module load pgi/19.10--binary gnu/8.4.0 cuda/10.1
+module load hpc-sdk/2021--binary gnu/8.4.0 cuda/11.0
 module load spectrum_mpi/10.3.1--binary boost/1.72.0--spectrum_mpi--10.3.1--binary
+module load cmake/3.20.0 python/3.8.2
 
-export PYTHONPATH=/m100_work/Pra18_4575_0/software/gpu/install/lib64/python/:$PYTHONPATH
+export PYTHONPATH=$HOME/install/lib/python/:$PYTHONPATH
 
 # gpu run with coreneuron
 mpirun ./special_wrapper.ppc64 -python -mpi bulb3dtest.py --tstop=1050 --coreneuron --gpu
@@ -74,46 +102,3 @@ mpirun ./special_wrapper.ppc64 -python -mpi bulb3dtest.py --tstop=1050 --coreneu
 
 Note that we are using `special_wrapper.ppc64` instead of `ppc64le/special` as a binary to launch. This is because [MPS](https://docs.nvidia.com/deploy/pdf/CUDA_Multi_Process_Service_Overview.pdf) service is currently not enabled on Marconi100. Using wrapper script, we start the MPS service before launching an application.
 
-
-### Installing NEURON+CoreNEURON from Source
-
-NEURON+CoreNEURON has been already installed in below location:
-
-```
-/m100_work/Pra18_4575_0/software/gpu/install
-```
-
-Use above installation unless you want to build everything from scratch. In order to do so, you can use following script:
-
-```
-module load profile/advanced
-module load pgi/19.10--binary gnu/8.4.0 cuda/10.1
-module load spectrum_mpi/10.3.1--binary boost/1.72.0--spectrum_mpi--10.3.1--binary
-module load cmake/3.17.1
-
-export PGI_LOCALRC=/m100_work/Pra18_4575_0/software/gpu/pgi/localr
-export OMPI_CXX=pgc++
-export OMPI_CC=pgcc
-export CC=mpicc
-export CXX=mpicxx
-
-git clone https://github.com/neuronsimulator/nrn.git
-
-mkdir -p nrn/build && cd nrn/build
-#git checkout 6f4ae452d771521ddaa357bb2ed8eb33c3f4a2d0
-
-# cmake, make and make install
-cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/install \
-	-DNRN_ENABLE_INTERVIEWS=OFF \
-	-DNRN_ENABLE_RX3D=OFF \
-	-DNRN_ENABLE_CORENEURON=ON \
-	-DPYTHON_EXECUTABLE=`which python` \
-	-DCORENRN_ENABLE_MPI=ON \
-	-DCORENRN_ENABLE_OPENMP=OFF \
-	-DCORENRN_ENABLE_GPU=ON \
-	-DNRN_ENABLE_BINARY_SPECIAL=ON \
-	-DNRN_ENABLE_SHARED=OFF \
-	-DNRN_ENABLE_INTERNAL_READLINE=ON
-make -j8
-make install
-```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ WIP
 
 ### How to run this model
 
-Make sure you have neuron with Python2 is installed (or neuron module loaded). You can then compile mod files as:
+Make sure you have neuron with Python3 installed (or neuron module loaded). You can then compile mod files as:
 
 ```
 cd sim

--- a/sim/GJ.py
+++ b/sim/GJ.py
@@ -24,7 +24,7 @@ def init_gap_junctions():
         mpriden = split.mpriden(mgid)
         if mpriden:
             glomid = mgid/nmxg
-            for sistermgid in range(glomid * nmxg, mgid)+range(mgid+1, (glomid+1)*nmxg):
+            for sistermgid in list(range(glomid * nmxg, mgid))+list(range(mgid+1, (glomid+1)*nmxg)):
                 if pc.gid_exists(sistermgid) > 0:
                     gap = h.Gap(mpriden(0.99))
                     if sistermgid != 189:

--- a/sim/all.py
+++ b/sim/all.py
@@ -43,7 +43,7 @@ for i in range(1, 5):
     ce = column_eval(data, 37)[0][1]
     ri = (imp[gl1] + imp[gl2])/2 #)-imp[37])/imp[37]
     x = cas(37,gl1,gl2) #log(cas(37,gl1,gl2)/((cas(gl1,37,gl2)+cas(gl2,37,gl1))/2.0))
-    print i, j, gl1, gl2, x, ri, ce
+    print(i, j, gl1, gl2, x, ri, ce)
     fo.write('%d %d %g %g %g\n'%(gl1, gl2, x, ri, ce[0]))
     index += 1
 fo.close()

--- a/sim/all2all.py
+++ b/sim/all2all.py
@@ -16,7 +16,7 @@ ptime = False
 def all2all(data, size=0):
   enter = h.startsw()
   r = _all2all(data, size)
-  if ptime and rank == 0: print 'all2all elapsed time = %g'% (h.startsw()-enter)
+  if ptime and rank == 0: print('all2all elapsed time = %g'% (h.startsw()-enter))
   return  r
 
 def _all2all(data, size=0):
@@ -49,4 +49,4 @@ if __name__ == '__main__':
   sizes = all2all(d, -1)
   d = all2all(d)
   for r in util.serialize():
-    print rank, sizes, d
+    print(rank, sizes, d)

--- a/sim/args.py
+++ b/sim/args.py
@@ -12,6 +12,8 @@ def parse_arguments():
                         help='Enable filemode execution of CoreNEURON')
     parser.add_argument('--filename', type=str, metavar='NAME', default='olfactory_bulb',
                         help='Output prefix (str)')
+    parser.add_argument('--dump-model', action='store_true', default=False,
+                        help='Dump CoreNEURON data and exit without running the NEURON simulation')
     args, _ = parser.parse_known_args()
     if args.gpu and not args.coreneuron:
         args.coreneuron = True

--- a/sim/balance.py
+++ b/sim/balance.py
@@ -13,12 +13,12 @@ def load_bal(cx, npart):
   s = {}
   if rank == 0:
     c = []
-    for i in r.values():
+    for i in list(r.values()):
       c += i
     del r
     #distribute by LPT
     parts = lpt(c, npart)
-    print statistics(parts)
+    print(statistics(parts))
     for i,p in enumerate(parts):
       s.update({i : p[1]})
   else:
@@ -27,17 +27,17 @@ def load_bal(cx, npart):
   local = all2all(s)
   del s
   if rank == 0:
-    print "load_bal time %g" % (h.startsw()-elapse)
+    print("load_bal time %g" % (h.startsw()-elapse))
   return local[0]
 
 if __name__ == '__main__':
   from util import serialize, finish
   if True:
     cx = [(10*rank+i, 10*rank+i) for i in range(1,5)]
-    print cx
+    print(cx)
     cx = load_bal(cx, nhost)
     for r in serialize():
-      print 'rank %d '%rank, cx
+      print('rank %d '%rank, cx)
   if nhost > 0:
     finish()
 

--- a/sim/bindict.py
+++ b/sim/bindict.py
@@ -53,7 +53,7 @@ def load(fname = None):
                 ggid = int(tk[1])
                 arc = float(tk[3])
                 entry = (ggid, arc)
-                if gid_dict.has_key(gid + 1):
+                if gid + 1 in gid_dict:
                     entry = gid_dict[gid + 1] + entry
                     gid_dict[gid + 1] = entry
                     add(mgid_dict, entry[0], True, gid, entry[3])
@@ -114,9 +114,9 @@ def query(gid, verbrec=False):
 
         
     if verbrec:
-        print descr
-        print '\n if you want use on vrecord write this params'
-        print '\t (' + str(gid) + ', ' + str(isec) + ', ' + str(x) + ')'
+        print(descr)
+        print('\n if you want use on vrecord write this params')
+        print('\t (' + str(gid) + ', ' + str(isec) + ', ' + str(x) + ')')
         
     return gid, isec, x, descr
 
@@ -129,7 +129,7 @@ def mknetwork(gloms=[]):
     import params
     import mgrs
     from common import rank, nhost
-    if len(gloms) == 0: gloms = range(params.Ngloms)
+    if len(gloms) == 0: gloms = list(range(params.Ngloms))
     for glomid in gloms:
 #        if glomid % nhost != rank:
 #            continue
@@ -140,7 +140,7 @@ def mknetwork(gloms=[]):
             mgid = _ci[0]
             ggid = _ci[3]
 
-            if not mgid_dict.has_key(mgid):
+            if mgid not in mgid_dict:
                 gids = []
                 mgid_dict.update({ mgid:gids })
             else:
@@ -153,7 +153,7 @@ def mknetwork(gloms=[]):
 
             gid_dict.update({ syngid:_ci })
 
-            if not ggid_dict.has_key(ggid):
+            if ggid not in ggid_dict:
                 gids = []
                 ggid_dict.update({ ggid:gids })
             else:
@@ -165,7 +165,7 @@ def mknetwork(gloms=[]):
 def save(filename):
     from struct import pack
     fo = open(filename, 'w')
-    for gid, ci in gid_dict.items():
+    for gid, ci in list(gid_dict.items()):
         fo.write(pack('>LLHfLf', gid, ci[0], ci[1], ci[2], ci[3], ci[5]))
     fo.close()
             
@@ -182,6 +182,6 @@ if __name__ == '__main__':
         try:
             query(int(argv[-1]), True)
         except:
-            print 'gid ', argv[-1], ' not found'
+            print('gid ', argv[-1], ' not found')
         
     quit()

--- a/sim/binsave.py
+++ b/sim/binsave.py
@@ -65,7 +65,7 @@ def save(prefix, t, g):
             fh.write(pack('>LL', gid, h))
 
         # output dictionary
-        for syn in getmodel().mgrss.values():
+        for syn in list(getmodel().mgrss.values()):
             if syn.md:
                 fdic.write(pack('>LLHfLf', syn.md_gid, syn.mgid, syn.isec, syn.xm, syn.ggid, syn.xg))
             

--- a/sim/binsave.py
+++ b/sim/binsave.py
@@ -40,7 +40,7 @@ def save(prefix, t, g):
 
 
 
-    ngroup = nhost / max(nhost / 64, 1)
+    ngroup = int(nhost / max(nhost / 64, 1))
     for rg, rp in group_serialize(ngroup):
         
         fname_data = '%s.sbg.%04d' % (prefix, rg)

--- a/sim/binspikes.py
+++ b/sim/binspikes.py
@@ -146,7 +146,7 @@ class SpikesReader:
           for j in range(hlen):
             gid, n = unpack('>LL', self.fi.read(8)) # read
 
-            if not self.header.has_key(gid):
+            if gid not in self.header:
               self.header.update({ gid:[(offset, n)] })
             else:
               self.header[gid].append((offset, n)) 
@@ -236,14 +236,14 @@ class SpikesReader:
         if gid < gid_mgrs_begin:
             return None
         if gid%2!=0 and params.use_fi_stdp:
-          if self.__initweights.has_key(gid):
+          if gid in self.__initweights:
             wi=self.__initweights[gid] 
           else:
             wi=0
           tpre=[0.]
-          if self.header.has_key(gid): tpre += self.retrieve(gid)
+          if gid in self.header: tpre += self.retrieve(gid)
           tpost=[0.]
-          if self.header.has_key(gid): tpost += self.retrieve(gid+1)
+          if gid in self.header: tpost += self.retrieve(gid+1)
           t,w = hebbian(wi,tpre,tpost)
           return t,w         
         else:        
@@ -315,7 +315,7 @@ class SpikesWriter:
     
     # write header
     fo = open(self.filename + '.header', 'wb')
-    for x in self.header.items():
+    for x in list(self.header.items()):
       fo.write(pack('>LL', x))
     fo.close()
     

--- a/sim/blanes.py
+++ b/sim/blanes.py
@@ -9,7 +9,7 @@ import params
 h.load_file('blanes.hoc')
 
 def load_blanes_dic(filename):
-    ggids_here = getmodel().granules.keys()
+    ggids_here = list(getmodel().granules.keys())
     blanes_here = set([x[1] for x in params.glom2blanes ])
     import struct
     with open(filename, 'rb') as fi:
@@ -33,7 +33,7 @@ def mk_gl2b_connections():
       w = None
     else:
       glomid, blanes_gid, w = x
-    if blanes_gid not in getmodel().blanes.keys():
+    if blanes_gid not in list(getmodel().blanes.keys()):
       continue
     for mtgid in range(glomid*params.Nmtufted_per_glom+params.gid_mtufted_begin, (glomid+1)*params.Nmtufted_per_glom+params.gid_mtufted_begin):
       getmodel().mt2blanes_connections.add((mtgid, blanes_gid, w))

--- a/sim/bulb3dtest.py
+++ b/sim/bulb3dtest.py
@@ -1,16 +1,18 @@
 import params
-
-
 import runsim
 import odors
+import sys
 from math import sqrt
 
-params.filename = 'bulb3dtest'
-params.tstop = 1050
-params.coreneuron = False
-params.gpu = False
+params.tstop = int(sys.argv[-5])
+params.coreneuron = bool(int(sys.argv[-4]))
+params.gpu = bool(int(sys.argv[-3]))
+params.filemode = bool(int(sys.argv[-2]))
+params.filename = sys.argv[-1]
+
 params.sniff_invl_min = params.sniff_invl_max = 500
 params.training_exc = params.training_inh = True
+
 from neuron import h
 h('sigslope_AmpaNmda=5')
 h('sigslope_FastInhib=5')

--- a/sim/bulb3dtest.py
+++ b/sim/bulb3dtest.py
@@ -1,7 +1,6 @@
 import params
 import runsim
 import odors
-import sys
 from math import sqrt
 
 params.sniff_invl_min = params.sniff_invl_max = 500

--- a/sim/cancel.py
+++ b/sim/cancel.py
@@ -1,6 +1,6 @@
 from os import system
 from sys import argv
-print argv[1]
+print(argv[1])
 try:
   iskip=int(argv[2])
 except:

--- a/sim/cellwriter.py
+++ b/sim/cellwriter.py
@@ -97,8 +97,8 @@ if __name__ == '__main__':
   cw = CellWriter('../vis/mccells')
   for gid in range(635):
     cw.write(genMitral(gid))
-    print 'cell', gid, 'generated and stored'
+    print('cell', gid, 'generated and stored')
   for gid in range(635,635+10*127):
     cw.write(genMTufted(gid))
-    print 'cell', gid, 'generated and stored'
+    print('cell', gid, 'generated and stored')
   cw.close()

--- a/sim/chk_gran_conn.py
+++ b/sim/chk_gran_conn.py
@@ -31,7 +31,7 @@ def chk_gran_conn():
   # for each granule, list of all mgid it connects to and vice versa
   g2m = {}
   m2g = {}
-  for mgrs in mgrss.values():
+  for mgrs in list(mgrss.values()):
     ggid = mgrs.ggid
     mgid = mgrs.mgid
     if mgrs.gd: # granule exists on this rank
@@ -45,7 +45,7 @@ def chk_gran_conn():
 
   a='Number of granules that go to mitral and mtufted (regardless of glomerulus)'
   na = 0
-  for ms in g2m.values():
+  for ms in list(g2m.values()):
     nmit = 0
     nmtuft = 0
     for mgid in ms:
@@ -54,13 +54,13 @@ def chk_gran_conn():
     na += 1 if nmit > 0 and nmtuft > 0 else 0
   na = int(pc.allreduce(na, 1))
   if pc.id() == 0:
-    print("%d %s" %(na, a))
+    print(("%d %s" %(na, a)))
 
   a='[total,imin,imax,iavg,xmin,xmax,xavg] granule connections to mitral'
   b='[total,imin,imax,iavg,xmin,xmax,xavg] granule connections to mtuft'
   nab=[[[],[],[],[]],[[],[],[],[]]]
 
-  for ms in g2m.values():
+  for ms in list(g2m.values()):
     # assume if first is mitral then all are mitrals otherwise mtuft
     dat = nab[0] if gidfunc.ismitral(ms[0]) else nab[1]
 

--- a/sim/complexity.py
+++ b/sim/complexity.py
@@ -30,7 +30,7 @@ def test():
   for i in cx:
      total_cx += i[0]
   total_cx = pc.allreduce(total_cx, 1)
-  if rank == 0: print 'total_cx=',total_cx
+  if rank == 0: print('total_cx=',total_cx)
   elapsed('write_cx_file')
 
 if __name__ == '__main__':

--- a/sim/convertdic.py
+++ b/sim/convertdic.py
@@ -7,17 +7,17 @@ def convert(filename1, filename2):
         
     gid_dict = {}
     bindict.load(filename1)
-    for gid, ci in bindict.gid_dict.items():
+    for gid, ci in list(bindict.gid_dict.items()):
         gid_dict[gid+params.gid_mgrs_begin-old_gid_mgrs_begin] = ci
     bindict.gid_dict = gid_dict
     bindict.save(filename2)
 
 convert('fullbulb0-v3.dic', 'fullbulb0-v4.dic')
-print '%0'
+print('%0')
 
 convert('fullbulb50-v3.dic', 'fullbulb50-v4.dic')
-print '%50'
+print('%50')
 
 convert('fullbulb100-v3.dic', 'fullbulb100-v4.dic')
-print '%100'
+print('%100')
 

--- a/sim/determine_connections.py
+++ b/sim/determine_connections.py
@@ -27,7 +27,7 @@ import lateral_connections as latconn
 
 
 gc2nconn = {}
-for ggid in granules.ggid2pos.keys():
+for ggid in list(granules.ggid2pos.keys()):
   if (ggid - params.gid_granule_begin) % nhost == rank:
     gc2nconn[ggid] = 0
   
@@ -72,7 +72,7 @@ def detect_intraglom_conn(cilist, GL_to_GCs):
   
   # merge all connections
   tocheck = set()
-  for rr, connpair in msg.items():
+  for rr, connpair in list(msg.items()):
     if rr >= rank:
       tocheck.update(connpair)
       
@@ -119,7 +119,7 @@ def detect_over_connected_gc(_cilist):
   
   # check for the over connected
   msg_remove = {}
-  for rr, ggids in msg.items():
+  for rr, ggids in list(msg.items()):
     for ggid in ggids:
       if gc2nconn[ggid] >= params.granule_nmax_spines:
         try:
@@ -135,12 +135,12 @@ def detect_over_connected_gc(_cilist):
   good_pair = []
   bad_pair = []
   
-  for ggids in msg_remove.values():
+  for ggids in list(msg_remove.values()):
     for ggid in ggids:
       bad_pair.append(ggid2ci[ggid][0])
       del ggid2ci[ggid][0]
 
-  for _cilist2 in ggid2ci.values():
+  for _cilist2 in list(ggid2ci.values()):
     for ci in _cilist2:
       good_pair.append(ci)
       
@@ -155,7 +155,7 @@ def mk_mconnection_info(model):
   cilist = []
 
   # initialization
-  for gid in model.mitrals.keys(): #+model.mtufted.keys():
+  for gid in list(model.mitrals.keys()): #+model.mtufted.keys():
     r[gid] = params.ranstream(gid, params.stream_latdendconnect) # init rng
     
     glomid = mgid2glom(gid) #params.cellid2glomid(gid) # init GCs connected to GL
@@ -164,7 +164,7 @@ def mk_mconnection_info(model):
 
 
   # lateral dendrites positions
-  for cellid, cell in model.mitrals.items(): #+model.mtufted.values():
+  for cellid, cell in list(model.mitrals.items()): #+model.mtufted.values():
     to_conn += latconn.lateral_connections(cellid, cell)
 
 
@@ -235,11 +235,11 @@ def mk_gconnection_info_part1(model):
       connection will not exist)
   '''
   model.rank_gconnections = {}
-  for cilist in model.mconnections.values():
+  for cilist in list(model.mconnections.values()):
     for ci in cilist:
       ggid = ci[3]
       r = gid2rank(ggid)
-      if not model.rank_gconnections.has_key(r):
+      if r not in model.rank_gconnections:
         model.rank_gconnections.update({r : []})
       model.rank_gconnections[r].append(ci)
 
@@ -264,7 +264,7 @@ if __name__ == '__main__':
 
   sizes = all2all(model.rank_gconnections, -1)
   for r in util.serialize():
-    print rank, " all2all sizes ", sizes
+    print(rank, " all2all sizes ", sizes)
 
-if rank == 0: print "determine_connections ", h.startsw()-t_begin
+if rank == 0: print("determine_connections ", h.startsw()-t_begin)
 

--- a/sim/distribute.py
+++ b/sim/distribute.py
@@ -49,7 +49,7 @@ def whole_cell_distrib(model):
   rr = {}
   for gid in model.gids:
     r = gid%nhost
-    if not rr.has_key(r):
+    if r not in rr:
       rr.update({r:[]})
     rr[r].append(gid);
   rr = all2all(rr)
@@ -63,7 +63,7 @@ def whole_cell_distrib(model):
   for r in gc:
     for ci in gc[r]:
       ggid = ci[3]
-      if not ggid2connection.has_key(ggid):
+      if ggid not in ggid2connection:
         ggid2connection.update({ggid:[]})
       ggid2connection[ggid].append(ci)
   for r in rr:
@@ -71,7 +71,7 @@ def whole_cell_distrib(model):
     mgci = []
     rr[r] = mgci
     for gid in gids:
-      if mc.has_key(gid):
+      if gid in mc:
         mgci.append(mc[gid])
       else:
         mgci.append(ggid2connection[gid])
@@ -88,13 +88,13 @@ def whole_cell_distrib(model):
   for r in mgci:
     for cil in mgci[r]:
       for ci in cil:
-        if not model.mgrss.has_key(mgrs.mgrs_gid(ci[0], ci[3], ci[6])):
+        if mgrs.mgrs_gid(ci[0], ci[3], ci[6]) not in model.mgrss:
           rsyn = mgrs.mk_mgrs(*ci[0:7])
           if rsyn:
             model.mgrss.update({rsyn.md_gid : rsyn})
   nmultiple = int(pc.allreduce(mgrs.multiple_cnt(), 1))
   if rank == 0:
-    print 'nmultiple = ', nmultiple
+    print('nmultiple = ', nmultiple)
   detectors = h.List("ThreshDetect")
   util.elapsed('%d ThreshDetect for reciprocalsynapses constructed'%int(pc.allreduce(detectors.count(),1)))
-  if rank == 0: print 'whole_cell_distrib time ', h.startsw() - enter
+  if rank == 0: print('whole_cell_distrib time ', h.startsw() - enter)

--- a/sim/fillgloms.py
+++ b/sim/fillgloms.py
@@ -148,7 +148,7 @@ def genFalseGloms():
         allGloms.append(newGl)
         
     while len(allGloms) < N_TOTAL_GLOMS:
-        print "Gloms are ", len(allGloms)
+        print("Gloms are ", len(allGloms))
         newGl, dep = genGlom()
         while noGood(newGl, dep, False):
             newGl, dep = genGlom()

--- a/sim/g_conn_stats.py
+++ b/sim/g_conn_stats.py
@@ -3,6 +3,6 @@ import bindict; bindict.load('miscd27c10.dic')
 import granules
 fo = open('gconnstats.txt', 'w')
 g = {}
-for ggid, conn in bindict.ggid_dict.items():
+for ggid, conn in list(bindict.ggid_dict.items()):
     fo.write('%g\n'%len(conn))
 fo.close()

--- a/sim/gapjunc.py
+++ b/sim/gapjunc.py
@@ -19,15 +19,15 @@ gj_max_g2=0.001
 def init():
     data = {}
     for uid in range(nhost):
-      data.update({ uid:(getmodel().mitrals.keys()) })
+      data.update({ uid:(list(getmodel().mitrals.keys())) })
     data = a2a.all2all(data)
     mgids = []
-    for _mgids in data.values(): mgids += _mgids
+    for _mgids in list(data.values()): mgids += _mgids
     mgids = set(mgids)
 
     # initialize source
     
-    for mgid in getmodel().mitrals.keys():
+    for mgid in list(getmodel().mitrals.keys()):
         mpriden = split.mpriden(mgid)
         if not mpriden:
           continue
@@ -58,7 +58,7 @@ def init():
             else:
                 sistergids += [mgid - 1]
             
-        sistergids = mgids.intersection(range(glomid * nmxg, glomid * nmxg + nmxg) + range(glomid * nmt + nmi, glomid * nmt + nmt + nmi)).difference([ mgid ])  
+        sistergids = mgids.intersection(list(range(glomid * nmxg, glomid * nmxg + nmxg)) + list(range(glomid * nmt + nmi, glomid * nmt + nmt + nmi))).difference([ mgid ])  
 
         for sistermgid in sistergids:
             gap = h.Gap(mpriden(0.99))
@@ -77,7 +77,7 @@ def init():
     pc.barrier()
 
     # initialize targets
-    for key, gap in getmodel().gj.items():
+    for key, gap in list(getmodel().gj.items()):
         mgid, sistermgid = key
         pc.target_var(gap, gap._ref_vgap, sistermgid)
 

--- a/sim/gen_weights.py
+++ b/sim/gen_weights.py
@@ -56,7 +56,7 @@ for perc in [0,50,100]:
                 
                 fo.write('%d %d 0\n' % (gid, wexc))
                 fo.write('%d %d 0\n' % (gid-1, winh))
-      print w_base, glomid, perc
+      print(w_base, glomid, perc)
 
     
     

--- a/sim/granules.py
+++ b/sim/granules.py
@@ -33,5 +33,5 @@ if __name__ == '__main__':
   if rank == 0:
     import params
     with open('../vis/granules.txt', 'w') as fo:
-      for gid, p in params.granules.ggid2pos.items():
+      for gid, p in list(params.granules.ggid2pos.items()):
         fo.write('%d %d %d %d 0\n'%((gid,)+p))

--- a/sim/growout.py
+++ b/sim/growout.py
@@ -176,7 +176,7 @@ def genNetwork(gloms, fname):
 
             nrn = genMitral(mid)
 
-            print "mitral ", mid
+            print("mitral ", mid)
 
             
 
@@ -202,7 +202,7 @@ def getGloms(gloms):
 
             newgloms += [ genMitral(mid) ]
 
-            print "mitral ", mid
+            print("mitral ", mid)
 
 
 
@@ -226,7 +226,7 @@ def genMitrals(mids, fname):
 
         nrn = genMitral(g)
 
-        print "mitral ", g
+        print("mitral ", g)
 
             
 

--- a/sim/lateral_connections.py
+++ b/sim/lateral_connections.py
@@ -23,7 +23,7 @@ def init():
   up = misc.Ellipsoid(params.bulbCenter, params.granAxisUp)
   dw = misc.Ellipsoid(params.bulbCenter, params.granAxisDw)
   
-  for p, ggid in granules.pos2ggid.items():
+  for p, ggid in list(granules.pos2ggid.items()):
     
     rng_type = params.ranstream(ggid, params.stream_granule_type)
     if rng_type.uniform(0, 1) < params.gc_type3_prob:
@@ -186,7 +186,7 @@ if __name__ == '__main__':
 
   def ggid2type_save(filename):
     with open(filename, 'w') as fo:
-      for gpos, gtype in pos2type.items():
+      for gpos, gtype in list(pos2type.items()):
         fo.write('%d %d\n' % (granules.pos2ggid[gpos], \
                             gtype) \
                  )
@@ -194,11 +194,11 @@ if __name__ == '__main__':
   ggid2type_save('../bulbvis/ggid2type.txt')
 
   with open('../bulbvis/granules.txt', 'w') as fo:
-    for ggid, p in granules.ggid2pos.items():
+    for ggid, p in list(granules.ggid2pos.items()):
       fo.write('%d ' % ggid)
       fo.write('%g %g %g '% p)
       fo.write('%d\n' % 0)
   n = [0]*3
-  for gtype in pos2type.values(): n[gtype]+=1
-  print n
-  print 'saved'
+  for gtype in list(pos2type.values()): n[gtype]+=1
+  print(n)
+  print('saved')

--- a/sim/lpt.py
+++ b/sim/lpt.py
@@ -47,7 +47,7 @@ def statistics(parts):
 if __name__ == '__main__':
   from util import serialize, finish
   for cx in ([(i, i) for i in range(10)],[]):
-    print len(cx), ' complexity items ', cx
+    print(len(cx), ' complexity items ', cx)
     pinfo = lpt(cx, 3)
-    print len(pinfo), ' lpt partitions ', pinfo
-    print statistics(pinfo)
+    print(len(pinfo), ' lpt partitions ', pinfo)
+    print(statistics(pinfo))

--- a/sim/mgrs.py
+++ b/sim/mgrs.py
@@ -69,7 +69,7 @@ class MGRS:
     self.md2ampanmda = None #NetCon to ampanmda
 
     if pc.gid_exists(self.md_gid) > 0. or pc.gid_exists(self.gd_gid) > 0.:
-      print "md_gid=%d and/or gd_gid=%d already registered" % (self.md_gid, self.gd_gid)
+      print("md_gid=%d and/or gd_gid=%d already registered" % (self.md_gid, self.gd_gid))
       raise RuntimeError
 
     if self.msecden:
@@ -160,11 +160,11 @@ class MGRS:
       self.md2ampanmda.delay = 1
 
   def pr(self):
-    print "%d %d <-> %d %d"%(self.mgid, self.md_gid, self.gd_gid, self.ggid)
+    print("%d %d <-> %d %d"%(self.mgid, self.md_gid, self.gd_gid, self.ggid))
     if self.msecden:
-      print self.msecden.name(), self.md.hname(), self.fi.hname(), self.gd2fi.hname(), " ", int(self.gd2fi.srcgid())
+      print(self.msecden.name(), self.md.hname(), self.fi.hname(), self.gd2fi.hname(), " ", int(self.gd2fi.srcgid()))
     if self.gpriden:
-      print self.gpriden.name(), self.gd.hname(), self.ampanmda.hname(), self.md2ampanmda.hname(), " ", int(self.md2ampanmda.srcgid())
+      print(self.gpriden.name(), self.gd.hname(), self.ampanmda.hname(), self.md2ampanmda.hname(), " ", int(self.md2ampanmda.srcgid()))
 
 
   def mg_dic_str(self):
@@ -207,7 +207,7 @@ def mk_mgrs(mgid, isec, xm, ggid, ipri, xg, slot):
     
 def multiple_cnt():
   cnt = 0;
-  for mgrs in getmodel().mgrss.values():
+  for mgrs in list(getmodel().mgrss.values()):
     if mgrs.slot > 0:
       if mgrs.gd: cnt += 1
       if mgrs.md: cnt += 1

--- a/sim/mgrs.py
+++ b/sim/mgrs.py
@@ -208,7 +208,7 @@ def mk_mgrs(mgid, isec, xm, ggid, ipri, xg, slot):
 def multiple_cnt():
   cnt = 0;
   for mgrs in list(getmodel().mgrss.values()):
-    if mgrs.slot > 0:
+    if mgrs.slot != 0: # slot is tuple not integer
       if mgrs.gd: cnt += 1
       if mgrs.md: cnt += 1
   return cnt

--- a/sim/mkmitral.py
+++ b/sim/mkmitral.py
@@ -76,8 +76,8 @@ if __name__ == "__main__":
   x = h.startsw()
   # note 259 has tertiary branches
   for i in range(10):
-    print "mid=",i
+    print("mid=",i)
     cells.append(mkmitral(i))
-  print "wall time ", h.startsw() - x, " seconds"
+  print("wall time ", h.startsw() - x, " seconds")
   h.load_file('select.hoc')
   

--- a/sim/multisplit_distrib.py
+++ b/sim/multisplit_distrib.py
@@ -60,7 +60,7 @@ def multisplit_distrib(model):
   for item in cxlist:
     gid = item[1][0]
     piece = item[1][1]
-    if not gid2pieces.has_key(gid):
+    if gid not in gid2pieces:
       gid2pieces.update({gid:[]})
     gid2pieces[gid].append(piece)
 
@@ -69,7 +69,7 @@ def multisplit_distrib(model):
   rr = {}
   for gid in model.gids:
     r = gid%nhost
-    if not rr.has_key(r):
+    if r not in rr:
       rr.update({r:[]})
     rr[r].append(gid);
   rr = all2all(rr)
@@ -86,7 +86,7 @@ def multisplit_distrib(model):
   for r in gc:
     for ci in gc[r]:
       ggid = ci[3]
-      if not ggid2connection.has_key(ggid):
+      if ggid not in ggid2connection:
         ggid2connection.update({ggid:[]})
       ggid2connection[ggid].append(ci)
       
@@ -96,7 +96,7 @@ def multisplit_distrib(model):
     rr[r] = mgci
     for gid in gids:
 
-      if mc.has_key(gid):
+      if gid in mc:
         mgci.append(mc[gid])
       elif gidfunc.isgranule(gid):
         mgci.append(ggid2connection[gid])
@@ -126,7 +126,7 @@ def multisplit_distrib(model):
   for r in mgci:
     for cil in mgci[r]:
       for ci in cil:
-        if not model.mgrss.has_key(mgrs.mgrs_gid(ci[0], ci[3], ci[6])):
+        if mgrs.mgrs_gid(ci[0], ci[3], ci[6]) not in model.mgrss:
           rsyn = mgrs.mk_mgrs(*ci[0:7])
           if rsyn:
             model.mgrss.update({rsyn.md_gid : rsyn})
@@ -147,7 +147,7 @@ def multisplit_distrib(model):
     model.blanes2gc[syn.gid] = syn
         
   if rank == 0:
-    print 'nmultiple = ', nmultiple
+    print('nmultiple = ', nmultiple)
   detectors = h.List("AmpaNmda")
   util.elapsed('%d ampanmda for reciprocalsynapses constructed'%int(pc.allreduce(detectors.count(),1)))
   detectors = h.List("FastInhib")
@@ -157,6 +157,6 @@ def multisplit_distrib(model):
   util.elapsed('%d mt to bc' % int(pc.allreduce(len(model.mt2blanes),1)))
   util.elapsed('%d bc to gc' % int(pc.allreduce(len(model.blanes2gc),1)))
 
-  if rank == 0: print 'multisplit_distrib time ', h.startsw() - enter
+  if rank == 0: print('multisplit_distrib time ', h.startsw() - enter)
 
  

--- a/sim/net_mitral_centric.py
+++ b/sim/net_mitral_centric.py
@@ -99,13 +99,13 @@ def build_synapses(model):
   for mgid in model.mconnections:
     for ci in model.mconnections[mgid]:
       #do not duplicate if already built because granule exists on this process
-      if not model.mgrss.has_key(mgrs.mgrs_gid(ci[0], ci[3], ci[6])):
+      if mgrs.mgrs_gid(ci[0], ci[3], ci[6]) not in model.mgrss:
         rsyn = mgrs.mk_mgrs(*ci[0:7])
         if rsyn:
           model.mgrss.update({rsyn.md_gid : rsyn})
   nmultiple = int(pc.allreduce(mgrs.multiple_cnt(), 1))
   if rank == 0:
-    print 'nmultiple = ', nmultiple
+    print('nmultiple = ', nmultiple)
   detectors = h.List("ThreshDetect")
   elapsed('%d ThreshDetect for reciprocalsynapses constructed'%int(pc.allreduce(detectors.count(),1)))
 
@@ -134,7 +134,7 @@ def read_mconnection_info(model, connection_file):
     if mgid in model.mitral_gids:
       slot = 0 #mgrs.gid2mg(md_gid)[3]
       cinfo = (mgid, isec, xm, ggid, 0, xg, slot, (0.,0.,0.))
-      if not model.mconnections.has_key(mgid):
+      if mgid not in model.mconnections:
         model.mconnections.update({ mgid:[] })
       model.mconnections[mgid].append(cinfo)
     rec = fi.read(22)
@@ -166,7 +166,7 @@ def build_net_round_robin(model, mitral_gids=set(range(params.Nmitral)), connect
   else:
     dc.mk_mconnection_info(model)  
   build_round_robin(model)  
-  if rank == 0: print 'build_subnet_round_robin ', h.startsw()-enter
+  if rank == 0: print('build_subnet_round_robin ', h.startsw()-enter)
   
 
 def build_round_robin(model):
@@ -189,7 +189,7 @@ def build_round_robin(model):
   build_synapses(model)
    
   elapsed('build_net_round_robin')
-  if rank == 0: print "round robin setuptime ", h.startsw() - t_begin
+  if rank == 0: print("round robin setuptime ", h.startsw() - t_begin)
 
 #build_net_round_robin(getmodel())
 
@@ -197,4 +197,4 @@ if __name__ == '__main__':
   from util import serialize
   model = getmodel()
   for r in serialize():
-    print "rank %d  %d mitrals  %d granules  %d MGRS nmultiple=%d max_multiple=%d" % (r,len(model.mitrals),len(model.granules), len(mgrss), mgrs.nmultiple, mgrs.max_multiple)
+    print("rank %d  %d mitrals  %d granules  %d MGRS nmultiple=%d max_multiple=%d" % (r,len(model.mitrals),len(model.granules), len(mgrss), mgrs.nmultiple, mgrs.max_multiple))

--- a/sim/odorstim.py
+++ b/sim/odorstim.py
@@ -72,7 +72,7 @@ class OdorStim:
       dict exists (usually from determine_connections.py).
     ''' 
     if rank == 0:
-      print("OdorStim %s start=%g dur=%g conc=%g"%(odorname, start, dur, conc))
+      print(("OdorStim %s start=%g dur=%g conc=%g"%(odorname, start, dur, conc)))
     self.odorname = odorname
     self.start = start
     self.dur = dur
@@ -103,7 +103,7 @@ class OdorStim:
       src.invl_max = params.sniff_invl_max
       src.noiseFromRandom123(0, params.stream_orn_act, 0)
       self.src = src
-    for gid, cell in model.mitrals.items(): 
+    for gid, cell in list(model.mitrals.items()): 
       peak = self.w_odor[mgid2glom(gid)]
       if gidfunc.ismitral(gid):
         g_e_baseline = params.orn_g_mc_baseline
@@ -145,7 +145,7 @@ class OdorStim:
   def ev(self, time):
     ''' set odors stimulation intensity '''
     model = getmodel()
-    for gid, cell in model.mitrals.items():
+    for gid, cell in list(model.mitrals.items()):
       
       if gidfunc.ismitral(gid):
         g_e_baseline = params.orn_g_mc_baseline
@@ -163,11 +163,11 @@ class OdorStim:
           cell.ornsyn.o(i).g_e_max = g_e_max
           cell.ornsyn.o(i).std_e =  std_e
     
-    for nc in self.netcons.values():
+    for nc in list(self.netcons.values()):
       nc.event(h.t)
 
     if self.verbose and rank == 0:
-      print 'activation of %s at %g (ms)\tinterval %g' % (self.odorname, time, self.next_invl)
+      print('activation of %s at %g (ms)\tinterval %g' % (self.odorname, time, self.next_invl))
 
     # set up for next sniff
     self.next_invl = self.rng_act.repick()
@@ -193,4 +193,4 @@ if __name__ == '__main__':
   ods.setup(determine_connections.mitrals, 10., 20., 100.)
   h.tstop = 150
   h.run()
-  print 't=', h.t
+  print('t=', h.t)

--- a/sim/orn.mod
+++ b/sim/orn.mod
@@ -327,9 +327,13 @@ static void bbcore_write(double* x, int* d, int* xx, int *offset, _threadargspro
 }
 
 static void bbcore_read(double* x, int* d, int* xx, int* offset, _threadargsproto_) {
-	assert(!_p_donotuse);
 	uint32_t* di = ((uint32_t*)d) + *offset;
 	nrnran123_State** pv = (nrnran123_State**)(&_p_donotuse);
+#if !NRNBBCORE
+    if(*pv) {
+        nrnran123_deletestream(*pv);
+    }
+#endif
 	*pv = nrnran123_newstream3(di[0], di[1], di[2]);
 	*offset += 3;
 }

--- a/sim/ostimhelper.mod
+++ b/sim/ostimhelper.mod
@@ -95,9 +95,13 @@ static void bbcore_write(double* x, int* d, int* xx, int *offset, _threadargspro
 }
 
 static void bbcore_read(double* x, int* d, int* xx, int* offset, _threadargsproto_) {
-  assert(!_p_space);
   uint32_t* di = ((uint32_t*)d) + *offset;
   nrnran123_State** pv = (nrnran123_State**)(&_p_space);
+#if !NRNBBCORE
+  if(*pv) {
+    nrnran123_deletestream(*pv);
+  }
+#endif
   *pv = nrnran123_newstream3(di[0], di[1], di[2]);
   *offset += 3;
 }

--- a/sim/params.py
+++ b/sim/params.py
@@ -16,6 +16,7 @@ GLOM_RADIUS = 50.
 coreneuron = False
 gpu = False
 filemode = False
+dump_model = False
 
 try:
     

--- a/sim/params.py
+++ b/sim/params.py
@@ -14,6 +14,7 @@ GLOM_RADIUS = 50.
 # coreneuron parameters
 coreneuron = False
 gpu = False
+filemode = False
 
 try:
     

--- a/sim/params.py
+++ b/sim/params.py
@@ -47,7 +47,7 @@ def load_params(_filename):
           glom2blanes.append((int(tk[0]), int(tk[1])))
           l = fi.readline()
     except:
-      print 'error during params import'
+      print('error during params import')
 
 from copy import copy
 from math import pi, sqrt

--- a/sim/params.py
+++ b/sim/params.py
@@ -184,3 +184,4 @@ coreneuron = args.coreneuron
 gpu = args.gpu
 filemode = args.filemode
 filename = args.filename
+dump_model = args.dump_model

--- a/sim/parrun.py
+++ b/sim/parrun.py
@@ -44,6 +44,12 @@ def prun(tstop):
 
   tnext_clean = clean_weights_interval
 
+  if params.dump_model:
+    pc.nrnbbcore_write('coredat')
+    if pc.id() == 0:
+      print('Dumping CoreNEURON data and exiting simulation')
+    return
+
   # if coreneuron is enabled, run it with coreneuron
   if params.coreneuron:
     from neuron import coreneuron

--- a/sim/parrun.py
+++ b/sim/parrun.py
@@ -48,6 +48,7 @@ def prun(tstop):
   if params.coreneuron:
     from neuron import coreneuron
     coreneuron.enable = True
+    coreneuron.filemode = params.filemode
     coreneuron.gpu = params.gpu
     if params.gpu:
       coreneuron.cell_permute = 2

--- a/sim/parrun.py
+++ b/sim/parrun.py
@@ -24,7 +24,7 @@ def prun(tstop):
   pc.setup_transfer()
   #pc.timeout(0)
   mindelay = pc.set_maxstep(10)
-  if rank == 0: print 'mindelay = %g'%mindelay
+  if rank == 0: print('mindelay = %g'%mindelay)
 
   cvode.active(0)
   h.stdinit()
@@ -34,13 +34,13 @@ def prun(tstop):
   solver_time = 0
 
   inittime = h.startsw()
-  if rank == 0: print 'cvode active=', cvode.active()
+  if rank == 0: print('cvode active=', cvode.active())
 
   if rank == 0:
     if clean_weights_active:
-      print 'weights reset active at %g ms' % clean_weights_interval
+      print('weights reset active at %g ms' % clean_weights_interval)
     else:
-      print 'weights reset not active'
+      print('weights reset not active')
 
   tnext_clean = clean_weights_interval
 
@@ -57,7 +57,7 @@ def prun(tstop):
   else:
     # neuron execution
     inittime = h.startsw() - inittime
-    print 'init time = %g'%inittime
+    print('init time = %g'%inittime)
 
     while h.t < tstop:
       told = h.t
@@ -81,7 +81,7 @@ def prun(tstop):
 
       if h.t == told:
         if rank == 0:
-          print "psolve did not advance time from t=%.20g to tnext=%.20g\n"%(h.t, tnext)
+          print("psolve did not advance time from t=%.20g to tnext=%.20g\n"%(h.t, tnext))
         break
       # weight_file(params.filename+('.%d'%isaved))
       # save spikes and dictionary in a binary format to
@@ -92,14 +92,14 @@ def prun(tstop):
 
   # for cmparison with CoreNEURON, print psolve time
   if rank == 0 and not params.coreneuron:
-    print 'Solver time : %g'% solver_time
+    print('Solver time : %g'% solver_time)
   
   runtime = h.startsw() - runtime
   comptime = pc.step_time()
   splittime = pc.vtransfer_time(1)
   gaptime = pc.vtransfer_time()
   exchtime = pc.wait_time() - exchtime
-  if rank == 0: print 'runtime = %g'% runtime
+  if rank == 0: print('runtime = %g'% runtime)
   printperf([comptime, exchtime, splittime, gaptime])
 
 def printperf(p):
@@ -112,14 +112,14 @@ def printperf(p):
   if rank > 0:
     return
   b = avgp[0]/maxp[0]
-  print 'Load Balance = %g'% b
-  print '\n     ',
-  for i in header: print '%12s'%i,
-  print '\n avg ',
-  for i in avgp: print '%12.2f'%i,
-  print '\n max ',
-  for i in maxp: print '%12.2f'%i,
-  print ''
+  print('Load Balance = %g'% b)
+  print('\n     ', end=' ')
+  for i in header: print('%12s'%i, end=' ')
+  print('\n avg ', end=' ')
+  for i in avgp: print('%12.2f'%i, end=' ')
+  print('\n max ', end=' ')
+  for i in maxp: print('%12.2f'%i, end=' ')
+  print('')
  
 if __name__ == '__main__':
   import common

--- a/sim/runsim.py
+++ b/sim/runsim.py
@@ -16,7 +16,7 @@ import net_mitral_centric as nmc
 from odorstim import OdorStim
 import gapjunc
 def build_complete_model(dicfile=''):
-  build_part_model(range(params.Ngloms), [], dicfile)
+  build_part_model(list(range(params.Ngloms)), [], dicfile)
   
 def build_part_model(gloms, mitrals, dicfile=''):
 
@@ -26,8 +26,8 @@ def build_part_model(gloms, mitrals, dicfile=''):
   # gids
   gids = set()
   for glomid in gloms:
-    gids.update(range(glomid * params.Nmitral_per_glom, (glomid+1) * params.Nmitral_per_glom) + \
-                range(glomid * params.Nmtufted_per_glom + params.gid_mtufted_begin, (glomid+1) * params.Nmtufted_per_glom + params.gid_mtufted_begin))
+    gids.update(list(range(glomid * params.Nmitral_per_glom, (glomid+1) * params.Nmitral_per_glom)) + \
+                list(range(glomid * params.Nmtufted_per_glom + params.gid_mtufted_begin, (glomid+1) * params.Nmtufted_per_glom + params.gid_mtufted_begin)))
   gids.update(mitrals)
   
   # distribute
@@ -52,12 +52,12 @@ def build_part_model(gloms, mitrals, dicfile=''):
   # print sections
   nc = h.List("NetCon")
   nc = int(pc.allreduce(nc.count(),1))
-  if rank == 0: print "NetCon count = ", nc
+  if rank == 0: print("NetCon count = ", nc)
   nseg = 0
   for sec in h.allsec():
     nseg += sec.nseg
   nseg = int(pc.allreduce(nseg, 1))
-  if rank == 0: print "Total # compartments = ", nseg
+  if rank == 0: print("Total # compartments = ", nseg)
 
   pc.spike_record(-1, parrun.spikevec, parrun.idvec)
   util.show_progress(200)
@@ -71,7 +71,7 @@ def build_part_model(gloms, mitrals, dicfile=''):
     vr.record(*rec)
 
 
-  if rank == 0: print 'total setup time ', h.startsw()-startsw
+  if rank == 0: print('total setup time ', h.startsw()-startsw)
 
 
 

--- a/sim/spk2weight.py
+++ b/sim/spk2weight.py
@@ -6,8 +6,8 @@ import bindict
 bindict.load('../../bulbvis/fullbulb-oldtraining-nomt.dic')
 tcut=None
 import mgrs
-mgid = range(37*5,37*5+5)
-for g, info in bindict.gid_dict.items():
+mgid = list(range(37*5,37*5+5))
+for g, info in list(bindict.gid_dict.items()):
   if info[0] not in mgid:
     continue
   try:
@@ -32,4 +32,4 @@ for g, info in bindict.gid_dict.items():
     w=0
   fo.write('%d %d %g\n' % (g,w,0))
 fo.close()
-print 'done'
+print('done')

--- a/sim/split.py
+++ b/sim/split.py
@@ -37,7 +37,7 @@ model = getmodel()
 
 
 def mpiece_exists(mgid):
-  return model.mgid2piece.has_key(mgid)
+  return mgid in model.mgid2piece
 
 def mgid2pieces(mgid):
   ''' return cell with existing pieces for mgid; None if does not exist.'''
@@ -183,10 +183,10 @@ if __name__ == "__main__":
   from mkmitral import mkmitral
   gid = 259
   mcell = mkmitral(gid) # according to mkmitral.py this has tertiary branches
-  print "mitral_complexity ", mitral_complexity(mcell)
-  print "cell_complexity = ", lb.cell_complexity(mcell)
+  print("mitral_complexity ", mitral_complexity(mcell))
+  print("cell_complexity = ", lb.cell_complexity(mcell))
   pieces = secden_indices_connected_to_soma(mcell)
   pieces.append(-1)
   splitmitral(gid, mcell, pieces)
   h.topology()
-  print "mgid2piece ", model.mgid2piece
+  print("mgid2piece ", model.mgid2piece)

--- a/sim/subsetsim.py
+++ b/sim/subsetsim.py
@@ -14,7 +14,7 @@ import params
 params.tstop=1000
 import odorstim
 odorstim.Fmax['Mint'][37]=0.7
-for i in range(0, 37)+range(38,127):
+for i in list(range(0, 37))+list(range(38,127)):
   odorstim.Fmax['Mint'][i] = 0
 import net_mitral_centric as nmc # nmc.dc sets up full model gids
 from common import *
@@ -31,8 +31,8 @@ def subset_distrib(gids, model):
 
 subset_distrib(subset, model)
 
-print 'mitrals ', model.mitral_gids
-print 'granules ', model.granule_gids
+print('mitrals ', model.mitral_gids)
+print('granules ', model.granule_gids)
 
 def mksubset(model):
   nmc.dc.mk_mitrals(model)
@@ -45,7 +45,7 @@ def mksubset(model):
   nmc.build_synapses(model)
   import GJ
   GJ.init_gap_junctions()
-  if rank == 0: print "network subset setuptime ", h.startsw() - nmc.t_begin
+  if rank == 0: print("network subset setuptime ", h.startsw() - nmc.t_begin)
 
 def get_and_make_subset_connections():
   #get the needed info
@@ -60,7 +60,7 @@ def get_and_make_subset_connections():
     slot = mgrs.gid2mg(mdgid)[3]
     rs = mgrs.mk_mgrs(c[0], c[1], c[2], c[3], 0, c[4], slot)
     model.mgrss.update({rs.md_gid : rs})
-  print "%d mgrs created"%len(model.mgrss)
+  print("%d mgrs created"%len(model.mgrss))
 
 def chk_consist(md_dict, m_dict, g_dict):
   #Incomplete consistency check
@@ -70,17 +70,17 @@ def chk_consist(md_dict, m_dict, g_dict):
       if gid < nmitral:
         assert(gid == mgid)
       elif gid < ncell:
-        assert(g_dict.has_key(gid))
+        assert(gid in g_dict)
       else:
-        assert(md_dict.has_key(gid))
+        assert(gid in md_dict)
         subset.add(gid)
   for ggid in model.granule_gids:
-    if g_dict.has_key(ggid):
+    if ggid in g_dict:
       for gid in g_dict[ggid]:
-        assert(md_dict.has_key(gid+1))
+        assert(gid+1 in md_dict)
         subset.add(gid+1)
     else:
-      print 'granule %d was not used in full model'%ggid
+      print('granule %d was not used in full model'%ggid)
   return subset
 
 def patstim(filename):
@@ -93,7 +93,7 @@ def patstim(filename):
       wanted.add(rs.gd_gid)
     if rs.gd:
       wanted.add(rs.md_gid)
-  print wanted
+  print(wanted)
   # read the spiketimes
   from binspikes import SpikesReader
   sr = SpikesReader(filename)
@@ -101,7 +101,7 @@ def patstim(filename):
   # to verify that the subset simulation is same as full network sim.
   spk_standard = {}
   for gid in model.gids:
-    if sr.header.has_key(gid):
+    if gid in sr.header:
       spk_standard.update({gid : sr.retrieve(gid)})
     else:
       spk_standard.update({gid : []})
@@ -110,8 +110,8 @@ def patstim(filename):
   tvec = h.Vector()
   gidvec = h.Vector()
   for gid in wanted:
-    if not sr.header.has_key(gid):
-      print 'no spikes from %d'%gid
+    if gid not in sr.header:
+      print('no spikes from %d'%gid)
       continue
     spikes = sr.retrieve(gid)
     for t in spikes:
@@ -165,20 +165,20 @@ def spkcompare():
     if nstd < 0: nstd = len(tstd)
     nsim = len(tsim)
     if nstd != nsim:
-      print "\nFor gid %d, during interval 0 to tstop=%g, different numbers of spikes %d %d"%(gid, h.tstop, nstd, nsim)
-      print "tstd"
+      print("\nFor gid %d, during interval 0 to tstop=%g, different numbers of spikes %d %d"%(gid, h.tstop, nstd, nsim))
+      print("tstd")
       tstd.printf()
-      print "tsim"
+      print("tsim")
       tsim.printf()
       return nstd, nsim
     else:
       if tstd.c().sub(tsim).abs().indwhere(">", 1.e-6) == -1.0:
-        print "\n%d spike times for gid %d are the same"%(nstd, gid)
+        print("\n%d spike times for gid %d are the same"%(nstd, gid))
       else:
-        print "\n%d spike times for gid %d are different, tsim-tstd:"%(nstd, gid)
+        print("\n%d spike times for gid %d are different, tsim-tstd:"%(nstd, gid))
         tsim.c().sub(tstd).printf()
         for i in range(nstd):
-          print "%d %g %g"%(i, tstd.x[i], tsim.x[i])
+          print("%d %g %g"%(i, tstd.x[i], tsim.x[i]))
 
 h.load_file("nrngui.hoc")
 

--- a/sim/txt2bin.py
+++ b/sim/txt2bin.py
@@ -20,7 +20,7 @@ fi.close()
 
 fo1=open(filespk+'.sbgh','wb')
 fo=open(filespk+'.sbg','wb')
-for gid, tspks in m.items():
+for gid, tspks in list(m.items()):
   fo.write(pack('>LL',gid,len(tspks)))
   for x in tspks:
     fo1.write(pack('>f',x))

--- a/sim/util.py
+++ b/sim/util.py
@@ -29,7 +29,7 @@ def finish():
   if nhost > 0:
     pc.runworker()
     pc.done()
-    print 'total elapsed time ', h.startsw()-startsw
+    print('total elapsed time ', h.startsw()-startsw)
     h.quit()
     
 elapsedtime=h.startsw()
@@ -39,13 +39,13 @@ def elapsed(message):
   '''
   global elapsedtime
   if rank == 0:
-    print "%s elapsedtime %g"% (message, h.startsw() - elapsedtime)
+    print("%s elapsedtime %g"% (message, h.startsw() - elapsedtime))
   elapsedtime = h.startsw()
 
 
 def progress(pinvl, swlast):
   sw = h.startsw()
-  print "t=%g wall interval %g"% (h.t, sw-swlast)
+  print("t=%g wall interval %g"% (h.t, sw-swlast))
   h.cvode.event(h.t+pinvl, (progress, (pinvl , sw)))
 
 def show_progress(invl):

--- a/sim/util.py
+++ b/sim/util.py
@@ -49,6 +49,7 @@ def progress(pinvl, swlast):
   h.cvode.event(h.t+pinvl, (progress, (pinvl , sw)))
 
 def show_progress(invl):
+  return
   global fih
   if rank == 0:
     fih = h.FInitializeHandler(2, (progress, (invl, h.startsw())))

--- a/sim/util.py
+++ b/sim/util.py
@@ -49,7 +49,8 @@ def progress(pinvl, swlast):
   h.cvode.event(h.t+pinvl, (progress, (pinvl , sw)))
 
 def show_progress(invl):
-  return
+  if params.coreneuron:
+    return
   global fih
   if rank == 0:
     fih = h.FInitializeHandler(2, (progress, (invl, h.startsw())))

--- a/sim/weightsave.py
+++ b/sim/weightsave.py
@@ -42,7 +42,7 @@ def weight_load(filename):
 def weight_file(prefix):
   wtime = h.startsw()
   mingroupsize = max(nhost/64, 1)
-  ng = nhost/mingroupsize
+  ng = int(nhost/mingroupsize)
   for r in group_serialize(ng):
     name = prefix + '.' + str(r[0])
     

--- a/sim/weightsave.py
+++ b/sim/weightsave.py
@@ -5,7 +5,7 @@ from common import getmodel
 
 def weight_reset():
   model = getmodel()
-  for rsyn in model.mgrss.values():
+  for rsyn in list(model.mgrss.values()):
     if rsyn.gd2fi:
       rsyn.gd2fi.weight[1] = 0
     if rsyn.md2ampanmda:
@@ -27,7 +27,7 @@ def weight_load(filename):
       inhib = False
 
     # has key
-    if model.mgrss.has_key(gid):
+    if gid in model.mgrss:
       rsyn = model.mgrss[gid]
       
       if inhib and rsyn.gd2fi:
@@ -62,4 +62,4 @@ def weight_file(prefix):
     f.close()
     #fdic.close()
     
-  if rank == 0 : print "weight_files %s.[0:%d] write time %g s" % (prefix, ng, h.startsw()-wtime)
+  if rank == 0 : print("weight_files %s.[0:%d] write time %g s" % (prefix, ng, h.startsw()-wtime))


### PR DESCRIPTION
2to3 along with minor bug fix. I suspect the effect of randomness will be different because of different ordering of dictionary iteration between python 2 and 3. Also the 2to3 tends to add list(...) around iterators which are not always needed for python3.
The use of MGRS.slot should be reviewed as it has changed from integer to apparently a location tuple. I believe the original slot
was introduced because of the possibility (perhaps never realized) of multiple connections with same 6 tuple definition. And that was substantively used with ```def mgrs_gid(gid_source, gid_target, slot=0):```. This def does not exist in this repository.