### PR TITLE
Update execution scripts and mod files

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module load spectrum_mpi/10.3.1--binary boost/1.72.0--spectrum_mpi--10.3.1--bina
 export PYTHONPATH=/m100_work/Pra18_4575_0/software/gpu/install/lib64/python/:$PYTHONPATH
 
 # gpu run with coreneuron
-mpirun ./special_wrapper.ppc64 -python -mpi bulb3dtest.py
+mpirun ./special_wrapper.ppc64 -python -mpi bulb3dtest.py 1050 1 1 0 output
 ```
 
 Note that we are using `special_wrapper.ppc64` instead of `ppc64le/special` as a binary to launch. This is because [MPS](https://docs.nvidia.com/deploy/pdf/CUDA_Multi_Process_Service_Overview.pdf) service is currently not enabled on Marconi100. Using wrapper script, we start the MPS service before launching an application.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ If there are no errors, `special` with CoreNEURON support will be built.
 
 #### Running model on GPU
 
-We are now ready to run model. To enable GPU support via CoreNEURON, make sure to change following variables to `True` in `bulb3dtest.py`:
+We are now ready to run model. To enable GPU support via CoreNEURON, you can pass the following command line argument to `bulb3dtest.py`:
 
 ```
-params.coreneuron = False
-params.gpu = False
+--coreneuron --gpu
 ```
 
 Also, if you are benchmarking model then make sure to select larger test case i.e. changing `runsim.build_part_model` in in `bulb3dtest.py`.
@@ -70,7 +69,7 @@ module load spectrum_mpi/10.3.1--binary boost/1.72.0--spectrum_mpi--10.3.1--bina
 export PYTHONPATH=/m100_work/Pra18_4575_0/software/gpu/install/lib64/python/:$PYTHONPATH
 
 # gpu run with coreneuron
-mpirun ./special_wrapper.ppc64 -python -mpi bulb3dtest.py 1050 1 1 0 output
+mpirun ./special_wrapper.ppc64 -python -mpi bulb3dtest.py --tstop=1050 --coreneuron --gpu
 ```
 
 Note that we are using `special_wrapper.ppc64` instead of `ppc64le/special` as a binary to launch. This is because [MPS](https://docs.nvidia.com/deploy/pdf/CUDA_Multi_Process_Service_Overview.pdf) service is currently not enabled on Marconi100. Using wrapper script, we start the MPS service before launching an application.

--- a/sim/args.py
+++ b/sim/args.py
@@ -1,0 +1,22 @@
+import argparse
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Olfactory-bulb-3d model simulation.')
+    parser.add_argument('--tstop', type=float, metavar='TIME', default=1050.,
+                        help='Simulation time (ms)')
+    parser.add_argument('--coreneuron', action='store_true', default=False,
+                        help='Enable CoreNEURON simulation')
+    parser.add_argument('--gpu', action='store_true', default=False,
+                        help='Enable GPU execution with CoreNEURON')
+    parser.add_argument('--filemode', action='store_true', default=False,
+                        help='Enable filemode execution of CoreNEURON')
+    parser.add_argument('--filename', type=str, metavar='NAME', default='olfactory_bulb',
+                        help='Output prefix (str)')
+    args = parser.parse_args()
+    if args.gpu and not args.coreneuron:
+        args.coreneuron = True
+        print("[Warning] --gpu option was given. Enabling automatically CoreNEURON execution")
+    if args.filemode and not args.coreneuron:
+        args.coreneuron = True
+        print("[Warning] --filemode option was given. Enabling automatically CoreNEURON execution")
+    return args

--- a/sim/bulb3dtest.py
+++ b/sim/bulb3dtest.py
@@ -1,16 +1,18 @@
 import params
-
-
 import runsim
 import odors
+import sys
 from math import sqrt
 
-params.filename = 'bulb3dtest'
-params.tstop = 1050
-params.coreneuron = False
-params.gpu = False
+params.tstop = int(sys.argv[-5])
+params.coreneuron = bool(int(sys.argv[-4]))
+params.gpu = bool(int(sys.argv[-3]))
+params.filemode = bool(int(sys.argv[-2]))
+params.filename = sys.argv[-1]
+
 params.sniff_invl_min = params.sniff_invl_max = 500
 params.training_exc = params.training_inh = True
+
 from neuron import h
 h('sigslope_AmpaNmda=5')
 h('sigslope_FastInhib=5')

--- a/sim/bulb3dtest.py
+++ b/sim/bulb3dtest.py
@@ -1,14 +1,7 @@
 import params
 import runsim
 import odors
-import sys
 from math import sqrt
-
-params.tstop = int(sys.argv[-5])
-params.coreneuron = bool(int(sys.argv[-4]))
-params.gpu = bool(int(sys.argv[-3]))
-params.filemode = bool(int(sys.argv[-2]))
-params.filename = sys.argv[-1]
 
 params.sniff_invl_min = params.sniff_invl_max = 500
 params.training_exc = params.training_inh = True

--- a/sim/orn.mod
+++ b/sim/orn.mod
@@ -327,9 +327,13 @@ static void bbcore_write(double* x, int* d, int* xx, int *offset, _threadargspro
 }
 
 static void bbcore_read(double* x, int* d, int* xx, int* offset, _threadargsproto_) {
-	assert(!_p_donotuse);
 	uint32_t* di = ((uint32_t*)d) + *offset;
 	nrnran123_State** pv = (nrnran123_State**)(&_p_donotuse);
+#if !NRNBBCORE
+    if(*pv) {
+        nrnran123_deletestream(*pv);
+    }
+#endif
 	*pv = nrnran123_newstream3(di[0], di[1], di[2]);
 	*offset += 3;
 }

--- a/sim/ostimhelper.mod
+++ b/sim/ostimhelper.mod
@@ -95,9 +95,13 @@ static void bbcore_write(double* x, int* d, int* xx, int *offset, _threadargspro
 }
 
 static void bbcore_read(double* x, int* d, int* xx, int* offset, _threadargsproto_) {
-  assert(!_p_space);
   uint32_t* di = ((uint32_t*)d) + *offset;
   nrnran123_State** pv = (nrnran123_State**)(&_p_space);
+#if !NRNBBCORE
+  if(*pv) {
+    nrnran123_deletestream(*pv);
+  }
+#endif
   *pv = nrnran123_newstream3(di[0], di[1], di[2]);
   *offset += 3;
 }

--- a/sim/params.py
+++ b/sim/params.py
@@ -1,4 +1,5 @@
 
+import args
 # -*- coding: cp1252 -*-
 
 # bulb spatial definition
@@ -177,3 +178,9 @@ gc_type3_prob=0
 
 vclamp = []
 
+args = args.parse_arguments()
+tstop = args.tstop
+coreneuron = args.coreneuron
+gpu = args.gpu
+filemode = args.filemode
+filename = args.filename

--- a/sim/params.py
+++ b/sim/params.py
@@ -14,6 +14,7 @@ GLOM_RADIUS = 50.
 # coreneuron parameters
 coreneuron = False
 gpu = False
+filemode = False
 
 try:
     

--- a/sim/parrun.py
+++ b/sim/parrun.py
@@ -48,6 +48,7 @@ def prun(tstop):
   if params.coreneuron:
     from neuron import coreneuron
     coreneuron.enable = True
+    coreneuron.filemode = params.filemode
     coreneuron.gpu = params.gpu
     if params.gpu:
       coreneuron.cell_permute = 2

--- a/sim/util.py
+++ b/sim/util.py
@@ -49,6 +49,7 @@ def progress(pinvl, swlast):
   h.cvode.event(h.t+pinvl, (progress, (pinvl , sw)))
 
 def show_progress(invl):
+  return
   global fih
   if rank == 0:
     fih = h.FInitializeHandler(2, (progress, (invl, h.startsw())))

--- a/sim/util.py
+++ b/sim/util.py
@@ -49,7 +49,8 @@ def progress(pinvl, swlast):
   h.cvode.event(h.t+pinvl, (progress, (pinvl , sw)))
 
 def show_progress(invl):
-  return
+  if params.coreneuron:
+    return
   global fih
   if rank == 0:
     fih = h.FInitializeHandler(2, (progress, (invl, h.startsw())))


### PR DESCRIPTION
- Added CLI options in the bulb3dtest.py to make the execution of the model more versatile from the command line
Example:
```
usage: bulb3dtest.py [-h] [--tstop TIME] [--coreneuron] [--gpu] [--filemode]
                     [--filename NAME]

Olfactory-bulb-3d model simulation.

optional arguments:
  -h, --help       show this help message and exit
  --tstop TIME     Simulation time (ms)
  --coreneuron     Enable CoreNEURON simulation
  --gpu            Enable GPU execution with CoreNEURON
  --filemode       Enable filemode execution of CoreNEURON
  --filename NAME  Output prefix (str)
 ```
- Updated mod files to be usable with NEURON and CoreNEURON after latest changes to psolve-direct
- Avoid calling progressbar events on CoreNEURON execution